### PR TITLE
Add support for static member functions and static properties

### DIFF
--- a/src/duktape-cpp/DuktapeCpp.h
+++ b/src/duktape-cpp/DuktapeCpp.h
@@ -3,5 +3,6 @@
 #include "./Types/All.h"
 #include "./Context.inl"
 #include "./Constructor.inl"
+#include "./PushConstructorInspector.inl"
 #include "./PushObjectInspector.inl"
 #include "./Exceptions.h"

--- a/src/duktape-cpp/EmptyInspector.h
+++ b/src/duktape-cpp/EmptyInspector.h
@@ -24,6 +24,9 @@ public:
     template <class C, class R, class ... A>
     void method(const char *name, R(C::*method)(A...) const) {}
 
+    template <class R, class ... A>
+    void static_method(const char *name, R(*method)(A...)) {}
+
     template <class C, class ... A>
     void construct(std::shared_ptr<C> (*constructor) (A...)) {}
 

--- a/src/duktape-cpp/EmptyInspector.h
+++ b/src/duktape-cpp/EmptyInspector.h
@@ -9,6 +9,9 @@ public:
     template <class C, class A> using Getter = A (C::*)() const;
     template <class C, class A> using Setter = void (C::*)(A a);
 
+    template <class A> using StaticGetter = A (*)();
+    template <class A> using StaticSetter = void (*)(A a);
+
     template <typename T>
     void constant(const char *name, T value) {}
 
@@ -17,6 +20,12 @@ public:
 
     template <class C, class A>
     void property(const char *name, Getter<C, A> getter) {}
+
+    template <class A>
+    void static_property(const char *name, StaticGetter<A> getter, StaticSetter<A> setter) {}
+
+    template <class A>
+    void static_property(const char *name, StaticGetter<A> getter) {}
 
     template <class C, class R, class ... A>
     void method(const char *name, R(C::*method)(A...)) {}

--- a/src/duktape-cpp/Method.h
+++ b/src/duktape-cpp/Method.h
@@ -246,8 +246,6 @@ struct StaticMethod {
 
     static int pushMethod(duk::Context &d, MethodPointer method) {
         // Store method pointer
-		printf("Push static\n");
-
         auto *mh = new MethodPointer(method);
 
         // Push function into stack

--- a/src/duktape-cpp/Method.h
+++ b/src/duktape-cpp/Method.h
@@ -112,6 +112,54 @@ struct MethodDispatcher<C, R> {
     }
 };
 
+
+/**
+ * Method dispatcher used to call static native method and push result to duktape stack
+ */
+template <class R, class ... A>
+struct StaticMethodDispatcher {
+    duk_ret_t dispatch(std::function<R(A...)> const &func, duk::Context &d) {
+        R res = call(func, d, std::index_sequence_for<A...>{});
+        Type<ClearType<R>>::push(d, std::move(res));
+        return 1;
+    }
+
+    template<std::size_t ... I>
+    R call(std::function<R(A...)> const &func, duk::Context &d, std::index_sequence<I...>) {
+        return func(ArgGetter<A, I, Type<ClearType<A>>::isPrimitive()>::get(d)...);
+    }
+};
+
+template <class ... A>
+struct StaticMethodDispatcher<void, A...> {
+    duk_ret_t dispatch(std::function<void(A...)> const &func, duk::Context &d) {
+        call(func, d, std::index_sequence_for<A...>{});
+        return 0;
+    }
+
+    template<std::size_t ...I>
+    void call(std::function<void(A...)> const &func, duk::Context &d, std::index_sequence<I...>) {
+        func(ArgGetter<A, I, Type<ClearType<A>>::isPrimitive()>::get(d)...);
+    }
+};
+
+template <>
+struct StaticMethodDispatcher<void> {
+    duk_ret_t dispatch(std::function<void()> const &func, duk::Context &d) {
+        func();
+        return 0;
+    }
+};
+
+template <class R>
+struct StaticMethodDispatcher<R> {
+    duk_ret_t dispatch(std::function<R()> const &func, duk::Context &d) {
+        R res = func();
+        Type<ClearType<R>>::push(d, res);
+        return 1;
+    }
+};
+
 /**
  * Push method into duktape stack
  * Stores pointer to method as hidden `method_ptr` field
@@ -183,6 +231,74 @@ struct Method {
     }
 };
 
+
+/**
+ * Push static method into duktape stack
+ * Stores pointer to method as hidden `method_ptr` field
+ *
+ * @param duk_context pointer to duktape context
+ * @param method pointer to method
+ * @return index of function in duktape stack
+ */
+template <class R, class ... A>
+struct StaticMethod {
+    typedef std::function<R(A...)> MethodPointer;
+
+    static int pushMethod(duk::Context &d, MethodPointer method) {
+        // Store method pointer
+		printf("Push static\n");
+
+        auto *mh = new MethodPointer(method);
+
+        // Push function into stack
+        auto fidx = duk_push_c_function(d, func, sizeof...(A));
+
+        // Add hidden pointer to method holder
+        duk_push_pointer(d, mh);
+        duk_put_prop_string(d, fidx, "\xff" "method_ptr");
+
+        duk_push_c_function(d, funcFinalizer, 1);
+        duk_set_finalizer(d, fidx);
+
+        return fidx;
+    }
+
+    /**
+     * This function is an entry point for methods called from duktape.
+     * It gets object and method pointers, reads parameters from duktape
+     * stack and makes actual calls to methods.
+     */
+    static duk_ret_t func(duk_context *d) {
+        // Get pointer to context
+        duk_push_global_stash(d);
+        duk_get_prop_string(d, -1, "self_ptr");
+        Context * dd = reinterpret_cast<Context*>(duk_get_pointer(d, -1));
+        duk_pop_2(d);
+
+        // Get pointer to method holder
+        duk_push_current_function(d);
+        duk_get_prop_string(d, -1, "\xff" "method_ptr");
+        MethodPointer * mh = reinterpret_cast<MethodPointer*>(duk_get_pointer(d, -1));
+        duk_pop_2(d);
+
+        // Use method dispatcher to call method
+        StaticMethodDispatcher<R, A...> m;
+        return m.dispatch(*mh, *dd);
+    }
+
+    static duk_ret_t funcFinalizer(duk_context *d) {
+        // object being finalized is at index 0
+        duk_get_prop_string(d, 0, "\xff" "method_ptr");
+        void * methodPtr = duk_get_pointer(d, -1);
+        duk_pop(d);
+
+        MethodPointer * mh = reinterpret_cast<MethodPointer*>(methodPtr);
+        delete mh;
+
+        return 0;
+    }
+};
+
 template <class C, class R, class ... A>
 void PushMethod(duk::Context &d, R (C::*method)(A...)) {
     Method<C, R, A...>::pushMethod(d, method);
@@ -191,6 +307,11 @@ void PushMethod(duk::Context &d, R (C::*method)(A...)) {
 template <class C, class R, class ... A>
 void PushMethod(duk::Context &d, R (C::*method)(A...) const) {
     Method<C, R, A...>::pushMethod(d, method);
+}
+
+template <class R, class ... A>
+void PushMethod(duk::Context &d, R (*method)(A...)) {
+    StaticMethod<R, A...>::pushMethod(d, method);
 }
 
 }}

--- a/src/duktape-cpp/PushConstructorInspector.h
+++ b/src/duktape-cpp/PushConstructorInspector.h
@@ -4,7 +4,6 @@
 
 #include "EmptyInspector.h"
 #include "Constructor.h"
-#include "Method.h"
 
 namespace duk { namespace details {
 
@@ -24,34 +23,13 @@ public:
     }
 
     template <class A>
-    void static_property(const char *name, StaticGetter<A> getter, StaticSetter<A> setter) {
-        duk_push_string(_ctx, name);
-        PushMethod(_ctx, getter);
-        PushMethod(_ctx, setter);
-        duk_def_prop(
-            _ctx,
-            -4,
-            DUK_DEFPROP_HAVE_GETTER |
-            DUK_DEFPROP_HAVE_SETTER
-        );
-    }
+    void static_property(const char *name, StaticGetter<A> getter, StaticSetter<A> setter);
 
     template <class A>
-    void static_property(const char *name, StaticGetter<A> getter) {
-        duk_push_string(_ctx, name);
-        PushMethod(_ctx, getter);
-        duk_def_prop(
-            _ctx,
-            -3,
-            DUK_DEFPROP_HAVE_GETTER
-        );
-    }
+    void static_property(const char *name, StaticGetter<A> getter);
 
     template <class R, class ... A>
-    void static_method(const char *name, R(*method)(A...)) {
-        PushMethod(_ctx, method);
-        duk_put_prop_string(_ctx, -2, name);
-    }
+    void static_method(const char *name, R(*method)(A...));
 
 private:
     duk::Context &_ctx;

--- a/src/duktape-cpp/PushConstructorInspector.h
+++ b/src/duktape-cpp/PushConstructorInspector.h
@@ -4,6 +4,7 @@
 
 #include "EmptyInspector.h"
 #include "Constructor.h"
+#include "Method.h"
 
 namespace duk { namespace details {
 
@@ -20,6 +21,12 @@ public:
     template <class C, class ... A>
     void construct(std::unique_ptr<C> (*constructor) (A...)) {
         ConstructorUnique<C, A...>::push(_ctx, constructor);
+    }
+
+    template <class R, class ... A>
+    inline void static_method(const char *name, R(*method)(A...)) {
+        PushMethod(_ctx, method);
+        duk_put_prop_string(_ctx, -2, name);
     }
 
 private:

--- a/src/duktape-cpp/PushConstructorInspector.h
+++ b/src/duktape-cpp/PushConstructorInspector.h
@@ -23,8 +23,32 @@ public:
         ConstructorUnique<C, A...>::push(_ctx, constructor);
     }
 
+    template <class A>
+    void static_property(const char *name, StaticGetter<A> getter, StaticSetter<A> setter) {
+        duk_push_string(_ctx, name);
+        PushMethod(_ctx, getter);
+        PushMethod(_ctx, setter);
+        duk_def_prop(
+            _ctx,
+            -4,
+            DUK_DEFPROP_HAVE_GETTER |
+            DUK_DEFPROP_HAVE_SETTER
+        );
+    }
+
+    template <class A>
+    void static_property(const char *name, StaticGetter<A> getter) {
+        duk_push_string(_ctx, name);
+        PushMethod(_ctx, getter);
+        duk_def_prop(
+            _ctx,
+            -3,
+            DUK_DEFPROP_HAVE_GETTER
+        );
+    }
+
     template <class R, class ... A>
-    inline void static_method(const char *name, R(*method)(A...)) {
+    void static_method(const char *name, R(*method)(A...)) {
         PushMethod(_ctx, method);
         duk_put_prop_string(_ctx, -2, name);
     }

--- a/src/duktape-cpp/PushConstructorInspector.inl
+++ b/src/duktape-cpp/PushConstructorInspector.inl
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "PushConstructorInspector.h"
+
+#include "Method.h"
+
+namespace duk { namespace details {
+
+template <class A>
+void PushConstructorInspector::static_property(const char *name, StaticGetter<A> getter, StaticSetter<A> setter) {
+    duk_push_string(_ctx, name);
+    PushMethod(_ctx, getter);
+    PushMethod(_ctx, setter);
+    duk_def_prop(
+        _ctx,
+        -4,
+        DUK_DEFPROP_HAVE_GETTER |
+        DUK_DEFPROP_HAVE_SETTER
+    );
+}
+
+template <class A>
+void PushConstructorInspector::static_property(const char *name, StaticGetter<A> getter) {
+    duk_push_string(_ctx, name);
+    PushMethod(_ctx, getter);
+    duk_def_prop(
+        _ctx,
+        -3,
+        DUK_DEFPROP_HAVE_GETTER
+    );
+}
+
+template <class R, class ... A>
+void PushConstructorInspector::static_method(const char *name, R(*method)(A...)) {
+    PushMethod(_ctx, method);
+    duk_put_prop_string(_ctx, -2, name);
+}
+
+}}


### PR DESCRIPTION
Hello.

I'm not completely sure if PushConstructorInspector is a good place for the code but this adds support for static member functions and properties.

The syntax matches the i.method and i.property functions:

```cpp
class Spaceship {
       [...]
       static std::string name () { return "ship"; }

       static int id;
       static GetId() { return id; }
       static SetId(int _id) { id = _id; }
}

// Inspect:
i.static_method("name", &Spaceship::name);
i.static_property("id", &Spaceship::GetId, &Spaceship::SetId);
```

I used "static_"-prefix to make the difference more visual clear because this prevents unintentional bugs.