### PR TITLE
Javascript callbacks can now be passed to C++

### DIFF
--- a/src/duktape-cpp/Types/Function.h
+++ b/src/duktape-cpp/Types/Function.h
@@ -167,6 +167,9 @@ struct Type<std::function<R(A...)>> {
         };
         val = std::move(fn);
     }
+
+    static constexpr bool isPrimitive() { return true; };
+
 };
 
 }


### PR DESCRIPTION
Javascript callbacks can now be passed to C++ as std::function arguments