### PR TITLE
fixed broken constructor during inheritance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.11)
 
-set(projname duktape_cpp)
+project(duktape_cpp)
 
 file(GLOB_RECURSE source_files "src/*.cpp")
 file(GLOB_RECURSE header_files "src/*.h")
@@ -9,12 +9,12 @@ file(GLOB_RECURSE inl_files "src/*.inl")
 include_directories(src)
 include_directories(dependencies/duktape/src)
 
-add_library(duktape_cpp ${source_files} ${header_files} ${inl_files})
+add_library(${PROJECT_NAME} ${source_files} ${header_files} ${inl_files})
 
 add_subdirectory(dependencies/duktape)
 
 add_subdirectory(tests)
 
-set_property(TARGET ${projname} PROPERTY CXX_STANDARD 14)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)
 
 add_subdirectory(examples)

--- a/src/duktape-cpp/PushConstructorInspector.h
+++ b/src/duktape-cpp/PushConstructorInspector.h
@@ -14,16 +14,23 @@ public:
 
     template <class C, class ... A>
     void construct(std::shared_ptr<C> (*constructor) (A...)) {
-        Constructor<C, A...>::push(_ctx, constructor);
+        if (!_hasConstructor) {
+            _hasConstructor = true;
+            Constructor<C, A...>::push(_ctx, constructor);
+        }
     }
 
     template <class C, class ... A>
     void construct(std::unique_ptr<C> (*constructor) (A...)) {
-        ConstructorUnique<C, A...>::push(_ctx, constructor);
+        if (!_hasConstructor) {
+            _hasConstructor = true;
+            ConstructorUnique<C, A...>::push(_ctx, constructor);
+        }
     }
 
 private:
     duk::Context &_ctx;
+    bool _hasConstructor = false;
 };
 
 }}

--- a/tests/ConstructorTests.cpp
+++ b/tests/ConstructorTests.cpp
@@ -148,12 +148,12 @@ TEST_CASE("PushConstructorInspector", "[duktape]") {
 
         duk_push_global_object(d);
 
-        duk::details::PushConstructorInspector i(d);
-
-        SimpleConstructible().inspect(i);
+        duk::details::PushConstructorInspector simpleInspector(d);
+        SimpleConstructible().inspect(simpleInspector);
         duk_put_prop_string(d, -2, "SimpleConstructible");
 
-        ComplexConstructible().inspect(i);
+        duk::details::PushConstructorInspector complexInspector(d);
+        ComplexConstructible().inspect(complexInspector);
         duk_put_prop_string(d, -2, "ComplexConstructible");
 
         auto evalRes = duk_peval_string(d, script);


### PR DESCRIPTION
If you try adding a constructor to the inspector of IBase in tests/PolymorphicTypesTests.cpp, you will end up with the constructor of the base class and no constructor at all for your current desired class. The solution is to capture the first constructor you encounter before traversing down the class hierarchy.